### PR TITLE
swagger page added to the project

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,191 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "IngredientImposter API",
+        "version": "1.0.0",
+        "description": "API for IngredientImposter authentication services"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:3000",
+            "description": "Development server"
+        }
+    ],
+    "paths": {
+        "/api/auth/sign-up/email": {
+            "post": {
+                "summary": "Sign Up",
+                "description": "Register a new user with email and password",
+                "tags": [
+                    "Authentication"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SignUpRequest"
+                            },
+                            "example": {
+                                "email": "test@gmail.com",
+                                "password": "Test123!",
+                                "name": "Connor"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful registration",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request - validation error"
+                    },
+                    "409": {
+                        "description": "Conflict - email already exists"
+                    }
+                }
+            }
+        },
+        "/api/auth/sign-in/email": {
+            "post": {
+                "summary": "Sign In",
+                "description": "Authenticate user with email and password",
+                "tags": [
+                    "Authentication"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SignInRequest"
+                            },
+                            "example": {
+                                "email": "test@gmail.com",
+                                "password": "Test123!",
+                                "callbackURL": "http://localhost:3000"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful authentication",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - invalid credentials"
+                    },
+                    "400": {
+                        "description": "Bad request - validation error"
+                    },
+                    "403": {
+                        "description": "Forbidden - invalid callback URL"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "SignUpRequest": {
+                "type": "object",
+                "required": [
+                    "email",
+                    "password",
+                    "name"
+                ],
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "User's email address"
+                    },
+                    "password": {
+                        "type": "string",
+                        "format": "password",
+                        "description": "User's password",
+                        "minLength": 8
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "User's display name"
+                    }
+                }
+            },
+            "SignInRequest": {
+                "type": "object",
+                "required": [
+                    "email",
+                    "password",
+                    "callbackURL"
+                ],
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "User's email address"
+                    },
+                    "password": {
+                        "type": "string",
+                        "format": "password",
+                        "description": "User's password"
+                    },
+                    "callbackURL": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "URL to redirect after successful authentication. Must be http://localhost:3000 for local development.",
+                        "example": "http://localhost:3000"
+                    }
+                }
+            },
+            "AuthResponse": {
+                "type": "object",
+                "properties": {
+                    "token": {
+                        "type": "string",
+                        "description": "Authentication token"
+                    },
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "User's unique identifier"
+                            },
+                            "email": {
+                                "type": "string",
+                                "description": "User's email address"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "User's display name"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            }
+        }
+    }
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,7 +1,7 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "title": "IngredientImposter API",
+        "title": "Recipe Generator API",
         "version": "1.0.0",
         "description": "API for IngredientImposter authentication services"
     },

--- a/src/app/(docs)/layout.tsx
+++ b/src/app/(docs)/layout.tsx
@@ -1,0 +1,21 @@
+export default function DocsLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <div style={{
+            backgroundColor: 'white',
+            minHeight: '100vh',
+            width: '100%',
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            overflow: 'auto'
+        }}>
+            {children}
+        </div>
+    );
+} 

--- a/src/app/(docs)/swagger/SwaggerWrapper.tsx
+++ b/src/app/(docs)/swagger/SwaggerWrapper.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import 'swagger-ui-react/swagger-ui.css';
+
+// Import SwaggerUI dynamically to avoid SSR issues
+const SwaggerUI = dynamic(() => import('swagger-ui-react'), {
+    ssr: false,
+    loading: () => (
+        <div style={{
+            padding: '20px',
+            color: '#666',
+            fontFamily: 'system-ui, -apple-system, sans-serif'
+        }}>
+            Loading API documentation...
+        </div>
+    ),
+});
+
+export default function SwaggerWrapper() {
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        // Only mount SwaggerUI on client side
+        setMounted(true);
+
+        // Store original console.error
+        const originalError = console.error;
+
+        // Override console.error to filter out specific warnings
+        console.error = (...args: any[]) => {
+            // Filter out UNSAFE_componentWillReceiveProps warning
+            if (typeof args[0] === 'string' &&
+                (args[0].includes('UNSAFE_componentWillReceiveProps') ||
+                    args[0].includes('Please update the following components'))) {
+                return;
+            }
+
+            // Pass through all other errors
+            originalError.apply(console, args);
+        };
+
+        // Cleanup: restore original console.error
+        return () => {
+            console.error = originalError;
+        };
+    }, []);
+
+    if (!mounted) return null;
+
+    return (
+        <div style={{
+            backgroundColor: 'white',
+            minHeight: '100vh',
+            padding: '20px'
+        }}>
+            <SwaggerUI url="/openapi.json" />
+        </div>
+    );
+} 

--- a/src/app/(docs)/swagger/page.tsx
+++ b/src/app/(docs)/swagger/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import SwaggerWrapper from './SwaggerWrapper';
+
+export default function SwaggerPage() {
+    return <SwaggerWrapper />;
+} 

--- a/src/types/swagger-ui-react.d.ts
+++ b/src/types/swagger-ui-react.d.ts
@@ -1,0 +1,14 @@
+declare module 'swagger-ui-react' {
+    import { ComponentType } from 'react';
+
+    interface SwaggerUIProps {
+        url?: string;
+        spec?: object;
+        docExpansion?: 'list' | 'full' | 'none';
+        defaultModelExpandDepth?: number;
+        [key: string]: any;
+    }
+
+    const SwaggerUI: ComponentType<SwaggerUIProps>;
+    export default SwaggerUI;
+} 


### PR DESCRIPTION
**Summary:**
This PR introduces a completely standalone Swagger UI documentation page. The new page is fully isolated from the main application, providing a clean, developer-focused interface for API exploration and testing.

**What’s New:**
Standalone Route:
Swagger UI is now available at /swagger (in the new (docs) route group).

**TypeScript Support:**
Includes a custom type definition for swagger-ui-react.

**OpenAPI Spec Integration:**
Loads the OpenAPI spec from /openapi.json in the public directory.

🗂️ **Files Added/Changed**
- src/app/(docs)/layout.tsx — Minimal layout for docs pages.
- src/app/(docs)/swagger/page.tsx — Standalone Swagger UI page.
- src/app/(docs)/swagger/SwaggerWrapper.tsx — Wrapper to suppress React warnings.
- src/types/swagger-ui-react.d.ts — TypeScript definitions for Swagger UI React.

**Access the docs:**
Go to http://localhost:3000/swagger (or your deployed domain /swagger).
Try out endpoints:
Use the interactive UI to test API endpoints, view schemas, and see example payloads.
Update the spec:

The Swagger UI page is not linked from the main app navigation (developer-only).
